### PR TITLE
Prevent multi-line comment start unless preceded by whitespace

### DIFF
--- a/nix.nanorc
+++ b/nix.nanorc
@@ -53,7 +53,7 @@ color brightred "\$\{[#!]?([-@*#?$!]|[0-9]+|[[:alpha:]_][[:alnum:]_]*)(\[([[:spa
 
 # Comments.
 color cyan "(^|[[:space:]])#.*$"
-color cyan start="/\*" end="\*/"
+color cyan start="(^|[[:space:]])/\*" end="\*/"
 
 # Trailing whitespace.
 color green "[[:space:]]+$"


### PR DESCRIPTION
The old code interprets this `cp -ur ${pkg.out}/* $out/` as a comment start and hightlights the rest of the file incorrectly. This change fixes that.